### PR TITLE
Open GitHub issues URL 

### DIFF
--- a/desktop/main_core.js
+++ b/desktop/main_core.js
@@ -163,10 +163,7 @@ function addToggleDevTools (menuHash) {
 }
 
 function reportBug (err) {
-  const errorSerialize = err ? {message: err.message, stack: err.stack} : false;
-  if (mainWindow) {
-    mainWindow.webContents.send('report_bug', errorSerialize);
-  }
+    shell.openExternal(`https://github.com/dragondropteam/desktop/issues/new?assignees=&labels=&template=bug_report.md&title=`);
 }
 
 function addHelpMenu (menuHash) {


### PR DESCRIPTION
When a user wants to report a bug use their web browser of choice to open the GitHub bug template for the desktop project 