### PR TITLE
phaser_toolbox_edit

### DIFF
--- a/desktop/project_types/visual_phaser/static/toolbox.xml
+++ b/desktop/project_types/visual_phaser/static/toolbox.xml
@@ -2748,15 +2748,6 @@
                     </value>
                 </block>
             </category>
-            <category name="Layer" colour="#6fe5e8">
-                <!--<block type="tilemap_layer_resize_world">
-                    <value name="LAYER">
-                        <shadow type="variables_get">
-                            <field name="VAR">defaultMap</field>
-                        </shadow>
-                    </value>
-                </block>-->
-            </category>
         </category>
         <category name="Physics" colour="#6A1B9A">
             <category name="Setup" colour="#6A1B9A">


### PR DESCRIPTION
Removed the Layer category from the Phaser toolbox, because it is empty.